### PR TITLE
Stick to global api

### DIFF
--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -66,9 +66,8 @@ const links = [
   },
 ]
 
-// Replace with the API keys from your widget installation page
+// Replace with the API key from your widget installation page
 const USERSNAP_GLOBAL_API_KEY = '<USERSNAP_GLOBAL_API_KEY>'
-const USERSNAP_API_KEY = '<USERSNAP_API_KEY>'
 
 // markup
 const IndexPage = () => {
@@ -79,7 +78,6 @@ const IndexPage = () => {
         {`
             window.onUsersnapCXLoad = function(api) {
               api.init();
-              api.show('${USERSNAP_API_KEY}') 
             }
             var script = document.createElement('script');
             script.defer = 1;

--- a/next-js/pages/_document.js
+++ b/next-js/pages/_document.js
@@ -1,8 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 
-// Replace with the API keys from your widget installation page
+// Replace with the API key from your widget installation page
 const USERSNAP_GLOBAL_API_KEY = '<USERSNAP_GLOBAL_API_KEY>'
-const USERSNAP_API_KEY = '<USERSNAP_API_KEY>'
 
 export default class MyDocument extends Document {
   render() {
@@ -20,7 +19,6 @@ export default class MyDocument extends Document {
                 // store the Usersnap global api on the window, if case you want to use it in other contexts
                 window.Usersnap = api; 
                 api.init();
-                api.show('${USERSNAP_API_KEY}') 
             }         
             `,
          }}

--- a/nuxt-js/plugins/usersnap.client.js
+++ b/nuxt-js/plugins/usersnap.client.js
@@ -1,13 +1,11 @@
-// Replace with the API keys from your widget installation page
+// Replace with the API key from your widget installation page
 const USERSNAP_GLOBAL_API_KEY = '<USERSNAP_GLOBAL_API_KEY>';
-const USERSNAP_API_KEY = '<USERSNAP_API_KEY>';
 
 export default () => {
   window.onUsersnapCXLoad = function(api) {
     // store the Usersnap global api on the window, if case you want to use it in other contexts
     window.Usersnap = api;
     api.init();
-    api.show(USERSNAP_API_KEY)
   }
   var script = document.createElement('script');
   script.defer = 1;


### PR DESCRIPTION
To reduce confusion for customer, remove reference of project api key. They should primarly use Targeting.